### PR TITLE
[10013:TXN_STATEMENT_TYPE_UNKNOWN]

### DIFF
--- a/server/transaction_service_base.cpp
+++ b/server/transaction_service_base.cpp
@@ -11758,10 +11758,10 @@ void TransactionService::initialize(const ManagerSet& mgrSet) {
 			ee_->addPeriodicTimer(adjustStoreMemoryPeriodicEvent,
 				ADJUST_STORE_MEMORY_CHECK_INTERVAL * 1000);
 
-			int32_t interval = CommonUtility::changeTimeSecondToMilliSecond(
-				mgrSet.config_->get<int32_t>(CONFIG_TABLE_SYNC_KEEP_LOG_CHECK_INTERVAL));
-			Event keepLogCheckEvent(eeSource_, TXN_KEEP_LOG_CHECK_PERIODICALLY, beginPId);
-			ee_->addPeriodicTimer(keepLogCheckEvent, interval);
+//			int32_t interval = CommonUtility::changeTimeSecondToMilliSecond(
+//				mgrSet.config_->get<int32_t>(CONFIG_TABLE_SYNC_KEEP_LOG_CHECK_INTERVAL));
+//			Event keepLogCheckEvent(eeSource_, TXN_KEEP_LOG_CHECK_PERIODICALLY, beginPId);
+//			ee_->addPeriodicTimer(keepLogCheckEvent, interval);
 		}
 
 		ee_->setHandler(EXECUTE_JOB, executeHandler_);


### PR DESCRIPTION
The following message keeps appearing in the event log file for V5.7:
- [10013:TXN_STATEMENT_TYPE_UNKNOWN] Unknown statement type

I fixed it by commenting out the unnecessary code.