### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/3rd_party/sqlite_mod/ext/rtree/rtree.c
+++ b/3rd_party/sqlite_mod/ext/rtree/rtree.c
@@ -3257,18 +3257,25 @@ static int rtreeInit(
 ** <num-dimension>*2 coordinates.
 */
 static void rtreenode(sqlite3_context *ctx, int nArg, sqlite3_value **apArg){
-  char *zText = 0;
   RtreeNode node;
   Rtree tree;
   int ii;
+  int nData;
+  int errCode;
+  sqlite3_str *pOut;
 
   UNUSED_PARAMETER(nArg);
   memset(&node, 0, sizeof(RtreeNode));
   memset(&tree, 0, sizeof(Rtree));
   tree.nDim = sqlite3_value_int(apArg[0]);
+  if( tree.nDim<1 || tree.nDim>5 ) return;
   tree.nBytesPerCell = 8 + 8 * tree.nDim;
   node.zData = (u8 *)sqlite3_value_blob(apArg[1]);
+  nData = sqlite3_value_bytes(apArg[1]);
+  if( nData<4 ) return;
+  if( nData<NCELL(&node)*tree.nBytesPerCell ) return;
 
+  pOut = sqlite3_str_new(0);
   for(ii=0; ii<NCELL(&node); ii++){
     char zCell[512];
     int nCell = 0;
@@ -3276,29 +3283,20 @@ static void rtreenode(sqlite3_context *ctx, int nArg, sqlite3_value **apArg){
     int jj;
 
     nodeGetCell(&tree, &node, ii, &cell);
-    sqlite3_snprintf(512-nCell,&zCell[nCell],"%lld", cell.iRowid);
-    nCell = (int)strlen(zCell);
+    if( ii>0 ) sqlite3_str_append(pOut, " ", 1);
+    sqlite3_str_appendf(pOut, "{%lld", cell.iRowid);
     for(jj=0; jj<tree.nDim*2; jj++){
 #ifndef SQLITE_RTREE_INT_ONLY
-      sqlite3_snprintf(512-nCell,&zCell[nCell], " %g",
-                       (double)cell.aCoord[jj].f);
+      sqlite3_str_appendf(pOut, " %g", (double)cell.aCoord[jj].f);
 #else
-      sqlite3_snprintf(512-nCell,&zCell[nCell], " %d",
-                       cell.aCoord[jj].i);
+      sqlite3_str_appendf(pOut, " %d", cell.aCoord[jj].i);
 #endif
-      nCell = (int)strlen(zCell);
     }
-
-    if( zText ){
-      char *zTextNew = sqlite3_mprintf("%s {%s}", zText, zCell);
-      sqlite3_free(zText);
-      zText = zTextNew;
-    }else{
-      zText = sqlite3_mprintf("{%s}", zCell);
-    }
+    sqlite3_str_append(pOut, "}", 1);
   }
-  
-  sqlite3_result_text(ctx, zText, -1, sqlite3_free);
+  errCode = sqlite3_str_errcode(pOut);
+  sqlite3_result_text(ctx, sqlite3_str_finish(pOut), -1, sqlite3_free);
+  sqlite3_result_error_code(ctx, errCode);
 }
 
 /* This routine implements an SQL function that returns the "depth" parameter


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in clone functions rtreenode() in `3rd_party/sqlite_mod/ext/rtree/rtree.c` sourced from [sqlite/sqlite](https://github.com/sqlite/sqlite). This issue, originally reported in [CVE-2019-8457](https://nvd.nist.gov/vuln/detail/CVE-2019-8457), was resolved in the repository via this commit https://github.com/sqlite/sqlite/commit/e41fd72acc7a06ce5a6a7d28154db1ffe8ba37a8.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!